### PR TITLE
ircd: disable config map suffix

### DIFF
--- a/ircd/kustomization.yaml
+++ b/ircd/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - resources.yaml
 configMapGenerator:
 - name: irc-config
+  generatorOptions:
+    disableNameSuffixHash: true
   files:
   - files/ircd.motd
   - files/ircd.yaml


### PR DESCRIPTION
This should disable ircd restarts when the config changes: will need to `/rehash` or kill pods manually for changes to take effect.

Long term solution should be a sidecar that watches for changes and sends a `SIGHUP` or rehash command somehow.