### PR TITLE
monitoring: use volume claim to persist Prometheus data

### DIFF
--- a/monitoring/kustomization.yaml
+++ b/monitoring/kustomization.yaml
@@ -12,6 +12,7 @@ patches:
   - cluster-wide.patch.yaml
   - grafana-dashboards.patch.yaml
   - prometheus-additional-scrape-configs.patch.yaml
+  - prometheus-persistent-volume.patch.yaml
 patchesJson6902:
   - target:
       version: v1

--- a/monitoring/prometheus-persistent-volume.patch.yaml
+++ b/monitoring/prometheus-persistent-volume.patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  namespace: monitoring
+  name: k8s
+spec:
+  volumeClaimTemplate:
+    spec:
+      resources:
+        requests:
+          storage: 2Gi


### PR DESCRIPTION
As of right now, every time both Prometheus instances are restarted, all the data is lost. This puts a limit at 2 GB, and we can see how that works out long term to see if we want to add more storage to it.

Requesting comments from: @lrvick @daurnimator @benharri 