### PR TITLE
monitoring: expose loki behind mtls auth

### DIFF
--- a/monitoring/loki/ingress.yaml
+++ b/monitoring/loki/ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: loki
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/ingress.class: nginx
+    # Enable client certificate authentication
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+    # Create the secret containing the trusted ca certificates
+    nginx.ingress.kubernetes.io/auth-tls-secret: "mtls/mtls-certs"
+    # Specify the verification depth in the client certificates chain
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "1"
+    # Specify if certificates are passed to upstream server
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "false"
+spec:
+  rules:
+  - host: loki.hashbang.sh
+    http:
+      paths:
+      - backend:
+          serviceName: loki
+          servicePort: 3100
+        path: /loki/
+  tls:
+  - hosts:
+    - loki.hashbang.sh
+    secretName: loki-tls

--- a/monitoring/loki/kustomization.yaml
+++ b/monitoring/loki/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   ## persistence.enabled=true
   ## serviceMonitor.enabled=true
   - resources.yaml
+  - ingress.yaml
 configMapGenerator:
   - name: loki
     files:


### PR DESCRIPTION
With this PR applied I was able to do this:
```shell
gpg -d ~/.config/mtls/daurnimator.key.gpg > tmp.key
logcli --addr https://loki.hashbang.sh/ --cert ~/.config/mtls/hashbang/hashbang.pem --key tmp.key labels namespace
rm tmp.key
```

It seems a little odd to have mtls on this and not the grafana GUI.
The grafana UI also supports auth "pass through" for loki, so it'd probably be a better idea to hook that up properly.

Still, I wanted to throw this PR up for discussion.