### PR TITLE
userdb-api: Migrate to userdb v1

### DIFF
--- a/userdb-api/resources.yaml
+++ b/userdb-api/resources.yaml
@@ -52,6 +52,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     external-dns.alpha.kubernetes.io/hostname: userdb.hashbang.sh
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   tls:
   - hosts:
@@ -61,7 +62,7 @@ spec:
   - host: userdb.hashbang.sh
     http:
       paths:
-      - path: /
+      - path: /v1(/|$)(.*)
         backend:
           serviceName: userdb-api
           servicePort: 80


### PR DESCRIPTION
Related: hashbang/userdb#43

This makes the first official version of UserDB, at https://userdb.hashbang.sh/v1. This also locks the version of userdb, any changes to the v1 API must be backwards compatible.