### PR TITLE
cert-manager: update to 0.16

### DIFF
--- a/cert-manager/requirements.lock
+++ b/cert-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: 0.15.1
-digest: sha256:f366c89efca6f92ad15ba6f94215fa666adf2c495cf023e36ea89856d468e699
-generated: "2020-06-03T03:39:48.738318721+10:00"
+  version: v0.16.0
+digest: sha256:ad301648e03d98dae86f84b39e27ccf277d0e008972b45599bb88974a6362a65
+generated: "2020-07-26T15:33:21.459963403+10:00"

--- a/cert-manager/requirements.yaml
+++ b/cert-manager/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: cert-manager
-  version: 0.15.1
+  version: 0.16.0
   repository: 'https://charts.jetstack.io'


### PR DESCRIPTION
https://github.com/jetstack/cert-manager/releases/tag/v0.16.0