### PR TITLE
upgrade to oragono 2.2.0

### DIFF
--- a/ircd/kustomization.yaml
+++ b/ircd/kustomization.yaml
@@ -14,4 +14,4 @@ configMapGenerator:
   - files/ircd.yaml
 images:
   - name: oragono/oragono:latest
-    digest: sha256:ccfec0df4e20ba7c94b5b520431573f77f7281e983208f9415a8baa4657233c1
+    digest: sha256:f3dbcfc77fa839414b3fe4335eaf724fd476484489ccfbba273fd04092bc60fa


### PR DESCRIPTION
[Oragono 2.2.0](https://hub.docker.com/layers/oragono/oragono/latest/images/sha256-f3dbcfc77fa839414b3fe4335eaf724fd476484489ccfbba273fd04092bc60fa?context=explore) was released last night. I have high confidence in its stability (since I've been dogfooding master continuously), so there's probably no reason to wait to upgrade.

Still working on getting version tags :-\