### PR TITLE
monitoring: set prometheus block retention to 1GB

### DIFF
--- a/monitoring/prometheus-persistent-volume.patch.yaml
+++ b/monitoring/prometheus-persistent-volume.patch.yaml
@@ -5,6 +5,9 @@ metadata:
   name: k8s
 spec:
   storage:
+    # This determines the maximum number of bytes that storage blocks can use
+    # (note that this does not include the WAL size, which can be substantial)
+    retensionSize: 1GB
     volumeClaimTemplate:
       spec:
         resources:

--- a/monitoring/prometheus-persistent-volume.patch.yaml
+++ b/monitoring/prometheus-persistent-volume.patch.yaml
@@ -7,9 +7,9 @@ spec:
   storage:
     # This determines the maximum number of bytes that storage blocks can use
     # (note that this does not include the WAL size, which can be substantial)
-    retensionSize: 1GB
+    retensionSize: 3GB
     volumeClaimTemplate:
       spec:
         resources:
           requests:
-            storage: 2Gi
+            storage: 4Gi


### PR DESCRIPTION
We are currently getting out of space errors. This should allow it to keep going
I sized it at 1GB as docs indicate that it should be smaller than the actual volume