### PR TITLE
ingress: enable SSL passthrough (for ArgoCD)

### DIFF
--- a/ingress-nginx/values.yaml
+++ b/ingress-nginx/values.yaml
@@ -19,6 +19,8 @@ nginx-ingress:
     service:
       annotations:
         service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
+    extraArgs:
+      enable-ssl-passthrough: ""
     autoscaling:
       enabled: true
       minReplicas: 2


### PR DESCRIPTION
This is required or the `argocd` binary won't be able to use gRPC calls to ArgoCD.