### PR TITLE
matterbridge: Add initial config

### DIFF
--- a/argocd/applications/matterbridge.yaml
+++ b/argocd/applications/matterbridge.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: matterbridge
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:hashbang/gitops.git
+    path: matterbridge/
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: matterbridge
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/kustomization.yaml
+++ b/argocd/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - applications/external-dns.yaml
   - applications/ingress-nginx.yaml
   - applications/ircd.yaml
+  - applications/matterbridge.yaml
   - applications/monitoring.yaml
   - applications/mtls.yaml
   - applications/site.yaml

--- a/matterbridge/README.md
+++ b/matterbridge/README.md
@@ -1,0 +1,7 @@
+# Matterbridge
+
+Bridges irc.hashbang.sh to irc.freenode.net
+
+![Matterbridge Status Indicator](https://argocd.hashbang.sh/api/badge?name=matterbridge)
+
+Upstream is https://github.com/42wim/matterbridge

--- a/matterbridge/kustomization.yaml
+++ b/matterbridge/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: matterbridge
+resources:
+- namespace.yaml
+- resources.yaml
+generators:
+- secret-generator.yaml
+images:
+- name: 42wim/matterbridge
+  digest: sha256:22c5235c8ad2f28591b3f6d6357e0b6a42700a362faa671fed84718f0f3b70ca
+

--- a/matterbridge/kustomization.yaml
+++ b/matterbridge/kustomization.yaml
@@ -2,11 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: matterbridge
 resources:
-- namespace.yaml
 - resources.yaml
 generators:
 - secret-generator.yaml
 images:
 - name: 42wim/matterbridge
   digest: sha256:22c5235c8ad2f28591b3f6d6357e0b6a42700a362faa671fed84718f0f3b70ca
-

--- a/matterbridge/kustomization.yaml
+++ b/matterbridge/kustomization.yaml
@@ -3,6 +3,12 @@ kind: Kustomization
 namespace: matterbridge
 resources:
 - resources.yaml
+configMapGenerator:
+- name: matterbridge-config
+  options:
+    disableNameSuffixHash: true
+  files:
+  - matterbridge.toml
 generators:
 - secret-generator.yaml
 images:

--- a/matterbridge/matterbridge-config.enc.yaml
+++ b/matterbridge/matterbridge-config.enc.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
+    annotations:
+        kustomize.config.k8s.io/needs-hash: true
     name: matterbridge-secret
 stringData:
     hashbang-password: ENC[AES256_GCM,data:kP/2u/wBqUOHU2tn1uS7NgzGCqg5xyorOw==,iv:orMASrV4SoRA+JUFfVArWfv8qnBmILywS2CQvVHJb5o=,tag:Fy1LrL1bDajxYa4dlfJPJw==,type:str]
@@ -10,8 +12,8 @@ sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2020-09-04T07:45:41Z'
-    mac: ENC[AES256_GCM,data:Q06UkFfxq1Hjkb4rT7NpT0mqyiNkHHROGr/ZE7WroipGsEo7zXFcRM+vskv5on6TGZQfjYqfPoZ0zl7zy3wR/C9XLC7B+JkQYD0Bn90y8Q/slyCuv49zQt3peQycSFo07N1rpuvMNdmb9MyXFBrLzvw9kFpROAxWj9hRlSaiMyA=,iv:ljkDFQHzR49XJQHLnWoC26/mKvs9INUbC1KfHEhbZBI=,tag:k0mlfA1M4qSVCvDmKmpAQQ==,type:str]
+    lastmodified: '2020-09-04T08:08:54Z'
+    mac: ENC[AES256_GCM,data:eJm58baOflYkuDfzB6hr6FBCdg6292xgJ+0gbMocZwjL2z67BbGsQkGJNCySi+qI6UHu5esepqkJXKkwUlErCC4+HaJxHE02+5L1yk4Uu9R3dTxg5C/Xeyfsg1uqGiPrVwCrL+34TBwvhb1d5rXw6GjicMx2twTM9DaoN8lzh7s=,iv:9XqA94iYRdm14vidXgkAT4ciz9Yd53PzXC2z+OqHpX4=,tag:pHUCqLMMAhohxWUJ9FxN2Q==,type:str]
     pgp:
     -   created_at: '2020-09-04T00:34:05Z'
         enc: |

--- a/matterbridge/matterbridge-config.enc.yaml
+++ b/matterbridge/matterbridge-config.enc.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: Secret
+stringData:
+    matterbridge.toml: ENC[AES256_GCM,data:Z9i5q07OHrM/h/BhBm1lTk4oLXvrI4CpA5itgj1ZvA805UrPnemszLYJBUvUhQb1x006GEe2SUOgjIqh8kgRD1Fqpi8u+/sMbdLEVjIMEnfdjcalLx4tYKoy6AibektSL0Z+WFzBxvvHml6MtpU8SlgrEVI9UmKhyomAT37XvARwWxb04H5VXxBDcWXaVuz2IVZz0h1GiWNIlVCGRoJygia91G6Sw95J30PkBOELoY1PYgyvqAxNiAewJ17HoxvQX2wfbISmswedghm17lut0HtBN+PP/GDA0tWqelikk2Lwj0ZCOB2SJ6WV0dO53Emm+fK4cg7Jjl3IgZl//Cv4XHVrNZdEfOG6UVoc+YO9CsBumW2z5lp+kQSDC2ORiD42cKjfGeV8MfImPsle+ZwI3qDbA6G4BQAPcetmCrukqmGLjZ2damAyYHroBEDxjkKI1QtXGCQpDc+AVhx56Yaxp9yyHVg0rIms+8dH6WPBtAno+NVbzikugaWw3x6YObD4BVTb/9aX3lLnDnUnxStVu42CLBjz1OSGBtAT8dgA2We2niP2CdbcC/jXSIZhMOI2g3+BqP8pZubXJ3qCfyRsurAOoIwzK0MnQzKEQ4AiOgkwKz9CXgdX/XsNdFsE72k9IZrwntGSoQsMHfDLvW/6A46VBb9Mwy+rfFV/pwnRjD9juN+/eI11kaBzuu/OkHNscoRk9CvAOwTiunCKx72n/GTo+Rn91XW9D0us2xwKRyHDWneGKda2LZG+ubJvIS00JF0=,iv:mWyGs8o3AlPj62MChvBPj+rlbLzlQa6FgH48m7ZSCsQ=,tag:MhWgV/x70mGm5z8wljtJQQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2020-09-04T00:34:05Z'
+    mac: ENC[AES256_GCM,data:QtQbm2DHWBGEQp8BICbleWE4dZ1ehesF6ZQfjV5wCWcu4NN3ztayArKUnP/ogBAltK+1ZSIbvznhna0GGmYr0GygoO/R8yA9/MrUA24v2OplCn3Nof1+S+gUYtSQY0LC3iKRT2CbEp8DnwncGD6sawaCWwdFt8ZnrMZygrrQetY=,iv:bffpjTQAUk5REg9iPcRgQsnsac5sj+nSK8LdbZ+QfZ4=,tag:zYA6AOyHBmJurRBYd+5VVA==,type:str]
+    pgp:
+    -   created_at: '2020-09-04T00:34:05Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA8PPSC5xMaBTAQ/9H73VHmYgZa0sGaiPADrVbKl5FCO3WDQ19QKwjn9tsSKm
+            DGEnyrGrwy+p1cZ/VDObfFqpIXEfy+Az3xzajsh0I3XjGftjO6Xfd6PXlYyHru2S
+            BR3H3QtAt1q8qJpQvbhtuLjag5kMOfDePidztBHzI2+VquS5RGX9uiYJjG2tA7mc
+            0YuMxOwRIt1e8mDygGmbuxsJpQRq524IFRcNe8iJ1+h8gTR4w0co3IK7W4cHilB5
+            r8kNq5HHUl4rWi2v0iV6lbozKcV0BKlKG3TiOPK8oKBkkcEYMVGYBnZbtTVe1y1g
+            itnQogrDv4m4NB10AaGbDyhA+n08LcJe1MSRJniOFyTrd18d4PFoiqHN6I08NTcp
+            WcTtf3+jNTzJNgL7OFFIqDSUBZ2W7r2OapHIxPwSGmI9zgaiXqr2f2uesGvGHJvt
+            6enq7SCXxxOKQNPdSnNwwZQzQqwDMYGQucxyhEGBKY8KjxGFYugpQyhNAvDkMzy6
+            KcEZLjheF0XuLuIbj0OWce6aqUNTJS4hoqFP5Bz+H78hCz7ouoLpsW4ZePibIkf5
+            CiGeZ5SxLrMTsBinWtMie3u4KIqdfhWyYjJG0q76GD+YKtNMksNW49CHDv6Rtc2L
+            xG6LRGys5zbBLXs7t407gun+7+cyU6SgBp2S/2BrY00HGrLeH78uo5gNoH3wTFLS
+            XAGoEIll5l7Vr2J8yR4kmMt/kt9V/wtoi8iW0zU5ydjT+TcLu2CYBElFJzLwmj7s
+            eEe9fG4YwDWTKZzJ4eK6iKJIvkpuRqkvN2l4tYm70voLaAjxFXwOgpx6qa7+
+            =TIhg
+            -----END PGP MESSAGE-----
+        fp: AAA9C1DBA861DCC065C4337CC3CF482E7131A053
+    -   created_at: '2020-09-04T00:34:05Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA4SNlT+wHnqoAQf5ARPAomvDxBdOZ5aP1yIGPF6t2qbcB0CyZPPJJv+tVixn
+            hROXxGKIP5zRlX8WH1xbMiODr+3Rav+jqsAeQ5vmSPzoFSZHj0jZWFNLbdjPswG/
+            bspQOT6W33wA4bLraXAxr+ToGSYfCVms+ES7qeLmrOH+HVlVTRLUUefERVbcW2vo
+            DTlIbz9YGEkMz4HOatD4Qdut4dSX83pgnHmm9JXIHWXm/pBV7byFTYzNo7+UQSwG
+            32Id6LNwdB11e3iO+w1HC+KkGYarrzR0ejIgCK1NudrI0fY7J+21b3ifmDaWysFi
+            8Bm+VzsxX6lnv6+P++hW/1uC+a/aM07HZ1g5hkFTNtJcAUbYOH+7yLI7ODFudNTS
+            UYSJuvqLhokBgHFj7McSHzxQFOh+6ua46skhm98LqKG1tI4wpuxcvfcCkTUzVgwx
+            6Sc1VqZUpb3Sq5XdFlj3wZoWPixwmgLYimlTIsw=
+            =1PGk
+            -----END PGP MESSAGE-----
+        fp: 8333F292B1BBD334A61E6F566785F7AF28DE7081
+    -   created_at: '2020-09-04T00:34:05Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA+mysOfPAHY0AQ/9E1grOgq1nnp70trjZKJeVsrqOwRtyqpFnEE5wPkaew4y
+            Y4o9vaI4gufBhxOPjVmlMj+JDZT40HdQXYQU2EXVusPjrYLBSsMP40hiGC2H1cM4
+            Tn2LEXkuGMVCUhoYicKQnkFq1Nl2Eou0UUMDtLztr0vAceiGbeMKWNDduw5bJl6Q
+            iE59ahIdmVcTgj+MSuLySLYtmNPzGYHrZrh8dwXqK8SisYh8GXhsLBHNIwYnpWr/
+            C+C6Drrx31jkvdjPbAvhRlqHAf/eZ/kfdLW69wH99oqX5cbKJE5zW78lgHI2yxrO
+            4k6Yse3V/e2A1fL3ScV9fVF2BhOXNhW2jpOa46DGrLclffxRhzIj4K2p5w1iJxJc
+            LDLolceHKcvwcQ7/Mz53p4n3VPhWOhHzNV8jpALyyDAMPiCyAd49kR1JFuYQmnsP
+            Sa7JHiXggVGfI9lFsSVt1tpI1LoFTjkMapNEV7BlNWCR0mnbpygNep1j8JWKIx1j
+            kNR+R1Fj3ZUo1vtSwvuHZcqW/XBP0UzBDDUIGt6eMjiFbTTuSJYbTRp/o8aUmtvi
+            g3ikgmLGbQnZH6dGbwK1sGfHgQ29+K3WTO8WMoz5MhttuYxYEqGMGjHZNFmLFcnd
+            HbUccTBP0zF69qp+1SKskhyvHnygHPNUJayCiToGqXrq8zN0v/8Nw+NMmjw8/BzS
+            XAHep2fUf3CK0PXP1sgLFa9tJpcRUBY/6VrWqPTi1Uaw5Rx7E4dniyfq3gMEjntU
+            Mm0yWH31JIsfPtwVKm3j+6Cqqi7ruLbiIPJLAZlR4kDhQn1GXodULPU2UMS/
+            =CXTT
+            -----END PGP MESSAGE-----
+        fp: 2131AD2652633390D79599A5121BFD94928027D1
+    encrypted_regex: ^(data|stringData)$
+    version: 3.5.0

--- a/matterbridge/matterbridge-config.enc.yaml
+++ b/matterbridge/matterbridge-config.enc.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Secret
 stringData:
-    matterbridge.toml: ENC[AES256_GCM,data:Z9i5q07OHrM/h/BhBm1lTk4oLXvrI4CpA5itgj1ZvA805UrPnemszLYJBUvUhQb1x006GEe2SUOgjIqh8kgRD1Fqpi8u+/sMbdLEVjIMEnfdjcalLx4tYKoy6AibektSL0Z+WFzBxvvHml6MtpU8SlgrEVI9UmKhyomAT37XvARwWxb04H5VXxBDcWXaVuz2IVZz0h1GiWNIlVCGRoJygia91G6Sw95J30PkBOELoY1PYgyvqAxNiAewJ17HoxvQX2wfbISmswedghm17lut0HtBN+PP/GDA0tWqelikk2Lwj0ZCOB2SJ6WV0dO53Emm+fK4cg7Jjl3IgZl//Cv4XHVrNZdEfOG6UVoc+YO9CsBumW2z5lp+kQSDC2ORiD42cKjfGeV8MfImPsle+ZwI3qDbA6G4BQAPcetmCrukqmGLjZ2damAyYHroBEDxjkKI1QtXGCQpDc+AVhx56Yaxp9yyHVg0rIms+8dH6WPBtAno+NVbzikugaWw3x6YObD4BVTb/9aX3lLnDnUnxStVu42CLBjz1OSGBtAT8dgA2We2niP2CdbcC/jXSIZhMOI2g3+BqP8pZubXJ3qCfyRsurAOoIwzK0MnQzKEQ4AiOgkwKz9CXgdX/XsNdFsE72k9IZrwntGSoQsMHfDLvW/6A46VBb9Mwy+rfFV/pwnRjD9juN+/eI11kaBzuu/OkHNscoRk9CvAOwTiunCKx72n/GTo+Rn91XW9D0us2xwKRyHDWneGKda2LZG+ubJvIS00JF0=,iv:mWyGs8o3AlPj62MChvBPj+rlbLzlQa6FgH48m7ZSCsQ=,tag:MhWgV/x70mGm5z8wljtJQQ==,type:str]
+    matterbridge.toml: ENC[AES256_GCM,data:bgMn/C9uGMQVBcpdN1qk5qcNdKuLgmKoK34ike5pO5GK8QRb2yIA7kDPtkmqMVE/4skKLwAyB/T4aKSFC3YlaV7p/WXlitr7jy43Gi7yCP5lEtXcvJFTXX6yFUdmhGXvNM8yaR2bs5Pgohz+iaBvP9Wm3vOM9YVrCZ0dwtQKMCv531gYfi0e9moL8kwbN342P+cKO6JpiytlU27kcrDmMU633myOajd9ZMW2PahyIcMqT60+fhc7gQm9bnBqcoteJ1b98/I8YaIWjl6VPS5QNHANJrcjPgloFr0dabBmYbPQT57vO7e1dREhB03MJY1AvZEgTavQ6qSHa3s3eFxXaijRjjbCIiqz7HLfmCtDeutLfCzivruhLtd+mOyH+v7TK7KTDbK/MuekY5QlnDBZQ+ga6zq3VUFYBc1DW0xnbbkmcqLRvywOLE7nhtuwJnyDUOGWVoZSvSXLnAvGiVMhxkCbPZvvfcWrOnCs9C8BNuVAiS9JEDTSjRUYVqilTTcoxlCLCvPXCf9lY7RHcrAm92vTaPb/F0Xf78DuXtrq+qKoWwLJizLgmd+3KEza3s8VWUk8xj1kAH9/w+XzIdhYI9euZIMKMABEeVyWJm9fjJNnbY1eAbU1oge56RDI9z/nQIT8955IE1ZpfH+1Bj1TcQTfs6NWbGpyYLNJFBXeMeLt6K03ytUFjWhB/xzgbJZqKsKV3trQx2ff8UdOrifyGczrLeC706ywIP0821BHIRRRj4rFyc+tTvULAa/N6W1jfPQNL/kQ4PSHN6Vjgs7NmDoBweNafJhWxy+N4bUvBWHmYjK2g1K455ySt78QUfb+gFjEkJTUejmATe91HeKyaneij12qQaH/79NwE0JLHY9g+iEZZaw9v5QQahw73/NC0KZBWQ5p97jA0Z1ba1QAe7ZuH9/h5/xKlcOb+ggOpronNZFxJ0+sUiMSOIz27kfPEvU59xX0mNV7IUwtsfyAu7kxhs3RwWrofs3h3jwYVZt8P/sJ6u0FKTGZ,iv:z7+f8tzarpL7KDFFLzNcb+pVHWdk8Xfm8QAypHIK1FM=,tag:tvoV97oQxzpEtIrc75WyNw==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2020-09-04T00:34:05Z'
-    mac: ENC[AES256_GCM,data:QtQbm2DHWBGEQp8BICbleWE4dZ1ehesF6ZQfjV5wCWcu4NN3ztayArKUnP/ogBAltK+1ZSIbvznhna0GGmYr0GygoO/R8yA9/MrUA24v2OplCn3Nof1+S+gUYtSQY0LC3iKRT2CbEp8DnwncGD6sawaCWwdFt8ZnrMZygrrQetY=,iv:bffpjTQAUk5REg9iPcRgQsnsac5sj+nSK8LdbZ+QfZ4=,tag:zYA6AOyHBmJurRBYd+5VVA==,type:str]
+    lastmodified: '2020-09-04T01:37:11Z'
+    mac: ENC[AES256_GCM,data:Gym8IkS9rd5AqTEp788Z5/si5jT1m1ertf60LCnsgONNECIGv3Vb5cTMF/pQdUNV9kD6Y5uU/YddYalbP06VieFPZQXWyKGklFkvQOWH1Rv5Qbg2pRnHYQRW4u8aA1RKczadzEMZQ6ytRmJIIzNOJ8FQjptx8PFInfNUCm+I1Ts=,iv:hSBZsw/yeugt+cOeUYAOAprwSdz9nGYh6mqI4AQgUW8=,tag:fHDm1hcNLW3XXHcZXAfT0Q==,type:str]
     pgp:
     -   created_at: '2020-09-04T00:34:05Z'
         enc: |

--- a/matterbridge/matterbridge-config.enc.yaml
+++ b/matterbridge/matterbridge-config.enc.yaml
@@ -1,13 +1,17 @@
 apiVersion: v1
 kind: Secret
+metadata:
+    name: matterbridge-secret
 stringData:
-    matterbridge.toml: ENC[AES256_GCM,data:bgMn/C9uGMQVBcpdN1qk5qcNdKuLgmKoK34ike5pO5GK8QRb2yIA7kDPtkmqMVE/4skKLwAyB/T4aKSFC3YlaV7p/WXlitr7jy43Gi7yCP5lEtXcvJFTXX6yFUdmhGXvNM8yaR2bs5Pgohz+iaBvP9Wm3vOM9YVrCZ0dwtQKMCv531gYfi0e9moL8kwbN342P+cKO6JpiytlU27kcrDmMU633myOajd9ZMW2PahyIcMqT60+fhc7gQm9bnBqcoteJ1b98/I8YaIWjl6VPS5QNHANJrcjPgloFr0dabBmYbPQT57vO7e1dREhB03MJY1AvZEgTavQ6qSHa3s3eFxXaijRjjbCIiqz7HLfmCtDeutLfCzivruhLtd+mOyH+v7TK7KTDbK/MuekY5QlnDBZQ+ga6zq3VUFYBc1DW0xnbbkmcqLRvywOLE7nhtuwJnyDUOGWVoZSvSXLnAvGiVMhxkCbPZvvfcWrOnCs9C8BNuVAiS9JEDTSjRUYVqilTTcoxlCLCvPXCf9lY7RHcrAm92vTaPb/F0Xf78DuXtrq+qKoWwLJizLgmd+3KEza3s8VWUk8xj1kAH9/w+XzIdhYI9euZIMKMABEeVyWJm9fjJNnbY1eAbU1oge56RDI9z/nQIT8955IE1ZpfH+1Bj1TcQTfs6NWbGpyYLNJFBXeMeLt6K03ytUFjWhB/xzgbJZqKsKV3trQx2ff8UdOrifyGczrLeC706ywIP0821BHIRRRj4rFyc+tTvULAa/N6W1jfPQNL/kQ4PSHN6Vjgs7NmDoBweNafJhWxy+N4bUvBWHmYjK2g1K455ySt78QUfb+gFjEkJTUejmATe91HeKyaneij12qQaH/79NwE0JLHY9g+iEZZaw9v5QQahw73/NC0KZBWQ5p97jA0Z1ba1QAe7ZuH9/h5/xKlcOb+ggOpronNZFxJ0+sUiMSOIz27kfPEvU59xX0mNV7IUwtsfyAu7kxhs3RwWrofs3h3jwYVZt8P/sJ6u0FKTGZ,iv:z7+f8tzarpL7KDFFLzNcb+pVHWdk8Xfm8QAypHIK1FM=,tag:tvoV97oQxzpEtIrc75WyNw==,type:str]
+    hashbang-password: ENC[AES256_GCM,data:kP/2u/wBqUOHU2tn1uS7NgzGCqg5xyorOw==,iv:orMASrV4SoRA+JUFfVArWfv8qnBmILywS2CQvVHJb5o=,tag:Fy1LrL1bDajxYa4dlfJPJw==,type:str]
+    freenode-password: ENC[AES256_GCM,data:mb02Xc4EqAHvH9lSlHCzNM61h/MEcB5gHQ==,iv:w8OzjE6tfmJn7j7x1R3p/TxxALrPF3MthkvZ7nA8pe0=,tag:ilrJ2u5A/n+sGi4FjiE0qg==,type:str]
+    matrix-password: ENC[AES256_GCM,data:vpbRRtLWoYsohaGuuwQt8FR8iuUMFbleMA==,iv:Hc/QJRE1DZxNyu9jJYQAjP7E59Av+ZWEzZAWRESQ3yo=,tag:PUyW96WJWyPn4T7ZfLnxhQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2020-09-04T01:37:11Z'
-    mac: ENC[AES256_GCM,data:Gym8IkS9rd5AqTEp788Z5/si5jT1m1ertf60LCnsgONNECIGv3Vb5cTMF/pQdUNV9kD6Y5uU/YddYalbP06VieFPZQXWyKGklFkvQOWH1Rv5Qbg2pRnHYQRW4u8aA1RKczadzEMZQ6ytRmJIIzNOJ8FQjptx8PFInfNUCm+I1Ts=,iv:hSBZsw/yeugt+cOeUYAOAprwSdz9nGYh6mqI4AQgUW8=,tag:fHDm1hcNLW3XXHcZXAfT0Q==,type:str]
+    lastmodified: '2020-09-04T07:45:41Z'
+    mac: ENC[AES256_GCM,data:Q06UkFfxq1Hjkb4rT7NpT0mqyiNkHHROGr/ZE7WroipGsEo7zXFcRM+vskv5on6TGZQfjYqfPoZ0zl7zy3wR/C9XLC7B+JkQYD0Bn90y8Q/slyCuv49zQt3peQycSFo07N1rpuvMNdmb9MyXFBrLzvw9kFpROAxWj9hRlSaiMyA=,iv:ljkDFQHzR49XJQHLnWoC26/mKvs9INUbC1KfHEhbZBI=,tag:k0mlfA1M4qSVCvDmKmpAQQ==,type:str]
     pgp:
     -   created_at: '2020-09-04T00:34:05Z'
         enc: |

--- a/matterbridge/matterbridge.toml
+++ b/matterbridge/matterbridge.toml
@@ -20,7 +20,7 @@ Server = "https://matrix.org"
 Login = "HashBot"
 Label = "m"
 RemoteNickFormat = "<{NICK}[{LABEL}]> "
-NoHomeServerSuffix = true
+NoHomeServerSuffix = false
 
 [[gateway]]
 name = "default"

--- a/matterbridge/matterbridge.toml
+++ b/matterbridge/matterbridge.toml
@@ -1,0 +1,35 @@
+[irc.hashbang]
+Server = "irc.hashbang.sh:6697"
+Nick = "HashBot"
+UseTLS = true
+Label = "h"
+RemoteNickFormat = "<{NICK}[{LABEL}]> "
+NickServNick = "HashBot"
+UseSASL = true
+
+[irc.freenode]
+Server = "irc.freenode.net:6697"
+Nick = "HashBot"
+UseTLS = true
+Label = "f"
+RemoteNickFormat = "<{NICK}[{LABEL}]> "
+NickServNick = "HashBot"
+
+[matrix.main]
+Server = "https://matrix.org"
+Login = "HashBot"
+Label = "m"
+RemoteNickFormat = "<{NICK}[{LABEL}]> "
+NoHomeServerSuffix = true
+
+[[gateway]]
+name = "default"
+enable = true
+
+[[gateway.inout]]
+account = "irc.hashbang"
+channel = "#!"
+
+[[gateway.inout]]
+account = "irc.freenode"
+channel = "#!"

--- a/matterbridge/matterbridge.toml
+++ b/matterbridge/matterbridge.toml
@@ -33,3 +33,7 @@ channel = "#!"
 [[gateway.inout]]
 account = "irc.freenode"
 channel = "#!"
+
+[[gateway.inout]]
+account = "matrix.main"
+channel = "#!:matrix.org"

--- a/matterbridge/namespace.yaml
+++ b/matterbridge/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: matterbridge

--- a/matterbridge/namespace.yaml
+++ b/matterbridge/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: matterbridge

--- a/matterbridge/resources.yaml
+++ b/matterbridge/resources.yaml
@@ -18,7 +18,7 @@ spec:
         image: 42wim/matterbridge
         volumeMounts:
         - name: matterbridge-config
-          mountPath: "/etc/matterbridge"
+          mountPath: /etc/matterbridge
       volumes:
       - name: matterbridge-config
         secret:

--- a/matterbridge/resources.yaml
+++ b/matterbridge/resources.yaml
@@ -19,7 +19,23 @@ spec:
         volumeMounts:
         - name: matterbridge-config
           mountPath: /etc/matterbridge
+        env:
+        - name: MATTERBRIDGE_IRC_HASHBANG_NICKSERVPASS
+          valueFrom:
+            secretKeyRef:
+              name: matterbridge-secret
+              value: hashbang-password
+        - name: MATTERBRIDGE_IRC_FREENODE_NICKSERVPASS
+          valueFrom:
+            secretKeyRef:
+              name: matterbridge-secret
+              value: freenode-password
+        - name: MATTERBRIDGE_MATRIX_MAIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: matterbridge-secret
+              value: matrix-password
       volumes:
       - name: matterbridge-config
-        secret:
-          secretName: matterbridge-config
+        configmap:
+          name: matterbridge-config

--- a/matterbridge/resources.yaml
+++ b/matterbridge/resources.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: matterbridge
+  labels:
+    app: matterbridge
+spec:
+  selector:
+    matchLabels:
+      app: matterbridge
+  template:
+    metadata:
+      labels:
+        app: matterbridge
+    spec:
+      containers:
+      - name: matterbridge
+        image: 42wim/matterbridge
+        volumeMounts:
+        - name: matterbridge-config
+          mountPath: "/etc/matterbridge"
+      volumes:
+      - name: matterbridge-config
+        secret:
+          secretName: matterbridge-config

--- a/matterbridge/secret-generator.yaml
+++ b/matterbridge/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: matterbridge-secrets
+files:
+- ./matterbridge-config.enc.yaml

--- a/matterbridge/secret-generator.yaml
+++ b/matterbridge/secret-generator.yaml
@@ -3,4 +3,4 @@ kind: ksops
 metadata:
   name: matterbridge-secrets
 files:
-- ./matterbridge-config.enc.yaml
+- matterbridge-config.enc.yaml


### PR DESCRIPTION
This uses matterbridge to bridge a channel on Hashbang IRC with a channel on Freenode.

TODO eventually: just bridge directly to Matrix, I believe you can have multiple bridges in one setup. I'm not doing this initially to avoid duplicating messages with the already-existing bridge.