### PR TITLE
ircd: Bump Oragono to a dev version just after 2.3.0

### DIFF
--- a/ircd/kustomization.yaml
+++ b/ircd/kustomization.yaml
@@ -13,4 +13,4 @@ configMapGenerator:
   - files/ircd.yaml
 images:
   - name: oragono/oragono:latest
-    digest: sha256:f3dbcfc77fa839414b3fe4335eaf724fd476484489ccfbba273fd04092bc60fa
+    digest: sha256:62d0fd2af5cbb8f0555204199aa7948f85fb14cb6f9cbc52c5ce198e1fa0df7f


### PR DESCRIPTION
This resolves a bug that one of our users has been having regarding the
way Oragono sends back PONGs in response to client PINGs. This pulls in
Oragono at commit bfb3fd702acd7103, the merge commit for the fix.

Link to release: https://github.com/oragono/oragono/releases/tag/v2.3.0