### PR TITLE
suppress user/ident field in irc

### DIFF
--- a/ircd/files/ircd.yaml
+++ b/ircd/files/ircd.yaml
@@ -138,6 +138,10 @@ server:
     # use ident protocol to get usernames
     check-ident: false
 
+    # ignore the supplied user/ident string from the USER command; always set the value to
+    # `~user` (literally) instead. this can potentially reduce confusion and simplify bans.
+    suppress-ident: true
+
     # password to login to the server
     # generated using  "oragono genpasswd"
     #password: ""


### PR DESCRIPTION
I realized that this switch is already present in 3ed047ccb890ba40, which you are now running.