### PR TITLE
Ksops 2.2.0

### DIFF
--- a/argocd/argo-cd-repo-server-ksops.patch.yaml
+++ b/argocd/argo-cd-repo-server-ksops.patch.yaml
@@ -6,37 +6,30 @@ metadata:
 spec:
   template:
     spec:
-      # 1. Define an emptyDir volume which will hold the custom binaries
+      # 1. Define an emptyDir volume which will hold the custom tools
       volumes:
         - name: custom-tools
           emptyDir: {}
-      # 2. Use an init container to download/copy custom binaries into the emptyDir
+      # 2. Use an init container to download/copy custom tools into the emptyDir
       initContainers:
         - name: install-ksops
-          # Match Argo CD Go version
           image: viaductoss/ksops:v2.2.0
           command: ["/bin/sh", "-c"]
           args:
             - echo "Installing KSOPS...";
-              export PKG_NAME=ksops;
-              mv ${PKG_NAME}.so /custom-tools/;
-              mv $GOPATH/bin/kustomize /custom-tools/;
+              mv ksops /custom-tools/;
               echo "Done.";
           volumeMounts:
             - mountPath: /custom-tools
               name: custom-tools
-      # 3. Volume mount the custom binary to the bin directory (overriding the existing version)
+      # 3. Volume mount the custom tools to their relevant directories (possibly overriding the existing version)
       containers:
         - name: argocd-repo-server
           volumeMounts:
-            - mountPath: /usr/local/bin/kustomize
-              name: custom-tools
-              subPath: kustomize
-              readOnly: true
               # Verify this matches a XDG_CONFIG_HOME=/.config env variable
-            - mountPath: /.config/kustomize/plugin/viaduct.ai/v1/ksops/ksops.so
+            - mountPath: /.config/kustomize/plugin/viaduct.ai/v1/ksops/ksops
               name: custom-tools
-              subPath: ksops.so
+              subPath: ksops
               readOnly: true
           # 4. Set the XDG_CONFIG_HOME env variable to allow kustomize to detect the plugin
           env:

--- a/argocd/argo-cd-repo-server-ksops.patch.yaml
+++ b/argocd/argo-cd-repo-server-ksops.patch.yaml
@@ -14,7 +14,7 @@ spec:
       initContainers:
         - name: install-ksops
           # Match Argo CD Go version
-          image: viaductoss/ksops:v2.1.5
+          image: viaductoss/ksops:v2.2.0
           command: ["/bin/sh", "-c"]
           args:
             - echo "Installing KSOPS...";

--- a/argocd/kustomization.yaml
+++ b/argocd/kustomization.yaml
@@ -60,8 +60,8 @@ images:
     digest: sha256:01e996b4b60edcc5cc042227c6965dd63ba68764c25d86b481b0d65f6e4da308
   - name: redis:5.0.8
     digest: sha256:de935cb5eb1d96a5b75c871cd408a728b89d100712ae4599eb994bb7a41a9336
-  - name: viaductoss/ksops:v2.1.5
-    digest: sha256:ac4a3655ea6ebe427dbfd4616c92aeea067388d2e46ea1a8503480d7a2e32087
+  - name: viaductoss/ksops:v2.2.0
+    digest: sha256:bb59c0605b5d7e4d945e9dce4016b80d003f78cce2a23f7e5354de8b9c8fec43
 generators:
   - secret-generator.yaml
 replicas:


### PR DESCRIPTION
Upgrades to KSOPS 2.2.0

Also change over to exec plugin. This means we no longer need to use the custom (dynamically linked) kustomize; so we drop that.