### PR TITLE
loki: only keep logs for 28 days

### DIFF
--- a/monitoring/loki/files/loki.yaml
+++ b/monitoring/loki/files/loki.yaml
@@ -52,10 +52,10 @@ storage_config:
   filesystem:
     directory: /data/loki/chunks
 chunk_store_config:
-  max_look_back_period: 0s
+  max_look_back_period: 672h
 table_manager:
-  retention_deletes_enabled: false
-  retention_period: 0s
+  retention_deletes_enabled: true
+  retention_period: 672h
 compactor:
   working_directory: /data/loki/boltdb-shipper-compactor
   shared_store: filesystem


### PR DESCRIPTION
https://grafana.com/docs/loki/latest/operations/storage/retention/