### PR TITLE
monitoring/loki: upgrade to loki 2.2.1

### DIFF
--- a/monitoring/loki/files/loki.yaml
+++ b/monitoring/loki/files/loki.yaml
@@ -1,61 +1,42 @@
 auth_enabled: false
+chunk_store_config:
+  max_look_back_period: 672h
+compactor:
+  shared_store: filesystem
+  working_directory: /data/loki/boltdb-shipper-compactor
 ingester:
-  chunk_idle_period: 3m
   chunk_block_size: 262144
+  chunk_idle_period: 3m
   chunk_retain_period: 1m
-  max_transfer_retries: 0
   lifecycler:
     ring:
       kvstore:
         store: inmemory
       replication_factor: 1
-
-    ## Different ring configs can be used. E.g. Consul
-    # ring:
-    #   store: consul
-    #   replication_factor: 1
-    #   consul:
-    #     host: "consul:8500"
-    #     prefix: ""
-    #     http_client_timeout: "20s"
-    #     consistent_reads: true
+  max_transfer_retries: 0
 limits_config:
   enforce_metric_name: false
   reject_old_samples: true
   reject_old_samples_max_age: 168h
 schema_config:
   configs:
-  - from: 2018-04-15
-    store: boltdb
-    object_store: filesystem
-    schema: v9
+  - from: "2020-11-19"
     index:
+      period: 24h
       prefix: index_
-      period: 168h
-  - from: 2020-11-19
-    store: boltdb-shipper
     object_store: filesystem
     schema: v11
-    index:
-      prefix: index_
-      period: 24h
+    store: boltdb-shipper
 server:
   http_listen_port: 3100
 storage_config:
-  boltdb:
-    directory: /data/loki/index
   boltdb_shipper:
     active_index_directory: /data/loki/boltdb-shipper-active
     cache_location: /data/loki/boltdb-shipper-cache
-    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+    cache_ttl: 24h
     shared_store: filesystem
   filesystem:
     directory: /data/loki/chunks
-chunk_store_config:
-  max_look_back_period: 672h
 table_manager:
   retention_deletes_enabled: true
   retention_period: 672h
-compactor:
-  working_directory: /data/loki/boltdb-shipper-compactor
-  shared_store: filesystem

--- a/monitoring/loki/kustomization.yaml
+++ b/monitoring/loki/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # Generated from loki-2.0.2 helm chart
+  # Generated from loki-2.5.0 helm chart
   ## persistence.enabled=true
   ## serviceMonitor.enabled=true
   - resources.yaml
@@ -10,5 +10,5 @@ configMapGenerator:
     files:
       - files/loki.yaml
 images:
-  - name: grafana/loki:2.0.0
-    digest: sha256:c613cf8e572666ac0237284a9fedfbc6d63690b8816cec4ae5acf391454ad9f8
+  - name: grafana/loki:2.2.1
+    digest: sha256:f18ec9b6102d8ff8a429d9c74ede7ba3061f31fb6821db5ca0f5f95e40cd4908

--- a/monitoring/loki/resources.yaml
+++ b/monitoring/loki/resources.yaml
@@ -140,7 +140,7 @@ spec:
         []
       containers:
         - name: loki
-          image: "grafana/loki:2.0.0"
+          image: "grafana/loki:2.2.1"
           args:
             - "-config.file=/etc/loki/loki.yaml"
           volumeMounts:


### PR DESCRIPTION
Now that we're past the 28 day retention for the old boltdb store we can revert our config to be more like the upstream one