### PR TITLE
argocd: Fix kellerfuchs' account

### DIFF
--- a/argocd/argocd-secret.enc.yaml
+++ b/argocd/argocd-secret.enc.yaml
@@ -14,8 +14,8 @@ stringData:
     accounts.dpflug.passwordMtime: ENC[AES256_GCM,data:mmV9QOw8TfOXZB+yfVHWUlrIo/E=,iv:CU/1p6iVzL6gJQ7TVacTSZjwKUWt/aJihQqA3cJ5b4Q=,tag:5dqQUDRpkMn1/KEImJ2QRQ==,type:str]
     accounts.drgrove.password: ENC[AES256_GCM,data:0Td783XdXNFZUCagcJYJA9eum9ul1TvCbeziUVAVEKyGtrMghEO64VVyKD28Owcd5U8NtqBCOY3DCy7x,iv:Nx7fJUf2LhQyP+lnk7M5APc9oVvmtaVM5XeaSgkL7gA=,tag:VYGlKsbDjJ70xqlbNTl77A==,type:str]
     accounts.drgrove.passwordMtime: ENC[AES256_GCM,data:3f4fuY6dJ02NhtqhFyAgpP5eYu0=,iv:hiHvJ6joLMNEyetHBuIa9zyr04ViylCxXuq8iYlAJ5U=,tag:HptnkbHpc0XIuDQBUCHU2Q==,type:str]
-    accounts.kellerfuchs.password: ENC[AES256_GCM,data:8Dq4lrXh5cySV6Fm/AIWriCKXxrQBm9dvsAzRJxE3YtuBdRHoJ+aVORrczvVSeeY+oUsGq42vNi0Ft1jX+ERvE1BkZr58ey8D6m4cmZH+7n1g58p7LpejZSkbkK4blcfNlE=,iv:3WX+BVFpv3hmurhbOWj89cRdorGsmC2nIh+SVHOEFfo=,tag:iVguyypg6wv6tw/xWRg3Gg==,type:str]
-    accounts.kellerfuchs.passwordMtime: ENC[AES256_GCM,data:HlScYVa7+eIDXX2Hg1hYnO4=,iv:7kGcU77J3WidXBuqt4eeKVRO+bO8VhG6p5OQYSmLHek=,tag:ToNDoczFqbNQzmjykA8S/g==,type:str]
+    accounts.kellerfuchs.password: ENC[AES256_GCM,data:AqaS0r+lpQNtTNXwqMxiQXENzP3j1SZUdx+YnNxXLCSU/D4fCqCV8flMCFC5jW3Uh4xaIwGUqVt/nq3y,iv:VxOBxXIX+OESgPhRyf/5TcfTrR0TQF8ghB3BhvWSy+w=,tag:ZKr5TMCuJzNoe5s51rYcIg==,type:str]
+    accounts.kellerfuchs.passwordMtime: ENC[AES256_GCM,data:shPodV2Uk4ke5duZ7BIYRWWrrXg=,iv:/SI5onO6tL1kO7EqN8Kc6GOCc03fknlwDjCbRaXX1rk=,tag:hlejsM8AUNuMzcGpJJGZvQ==,type:str]
     accounts.ryan.password: ENC[AES256_GCM,data:ZEo2Vdc3s/qRgNXnVhEOU6cD9DuqcIcJnvzi9LjIhMUb1R6suBQ+CRkSPEEjVrXPIjpFPSEfYZ0i3KYF,iv:J6A5Igy+N6l9rq7uglRqS0A6ex+TYOoUvccQI6Yx500=,tag:AxQeSnjVWpgPq7pSHHm1TA==,type:str]
     accounts.ryan.passwordMtime: ENC[AES256_GCM,data:b3+Kc1I7hMg3Eugw5bSF5FneTWk=,iv:ryzukGqXUVqKLKMCY/MEHJkc7O4DEMTAKAl2q1bGD8U=,tag:el2340cMdkV1JK0oAL9CCw==,type:str]
     accounts.lrvick.password: ENC[AES256_GCM,data:muYGgfQNVrpK17otA1hB01s3/BmwhBaTrkcXPsvZJ+F+5SCeJh6/8TqxqH6PmwLRNaIjMsChYQvtPB4X,iv:aORIWDdKtTivdQosc1H94T690o932p9c7OmsBUXWcmw=,tag:oL1USvSdZOAT3Y7MkSjmgg==,type:str]
@@ -27,8 +27,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-04-16T21:36:14Z"
-    mac: ENC[AES256_GCM,data:rsF5WkxV6zgKD36XCmVY9ZBUTlTP01zvalT1jSi1KvrY1boyyOnnS3j+P40hmVLTBlkLBE3G/oIpVMIaGjRM8XUZ6E7gYmusOynDGDYHK1FWnsn9/Ugm1ULDBbioWLFXXDz98iqfs/Vl6heW/LaVYFqh2Af6OLi+hCTT0b9Q/HE=,iv:zUhTcbhrorWQs+fvwH8JGz3PcR7yIIsgEU2Oj6eBEVc=,tag:PjOOiqUen+7JyT5YsmrF2g==,type:str]
+    lastmodified: "2023-04-16T23:55:44Z"
+    mac: ENC[AES256_GCM,data:UDmO/u+qMahD2OohelXSH/79zkGrW0Azed1ntsubX6CasJx7RWVvQglO7fRH9ixeOz5FT3EsBrt2lh5sAbnAoHKekR/SO9S2FdhjwQi+NipNOG6INg4xjI11dmtdfrq/OU1qyA8MGslFivC0VYmk8id85AHlLVLq/C0hjSZa/xY=,iv:eW9imYzqRNDjIiNRSluGtigdENfm+uxrFZOh73Palu4=,tag:gWeOYkt3GvyPM/+9yfFItQ==,type:str]
     pgp:
         - created_at: "2023-04-16T21:14:55Z"
           enc: |-


### PR DESCRIPTION
Apparently argocd only accepts RFC 3339 time format (not ISO 8601) and doesn't like modern password hashes either.  >_>'