### PR TITLE
upgrade Ergo to 2.13.0

### DIFF
--- a/ircd/kustomization.yaml
+++ b/ircd/kustomization.yaml
@@ -13,4 +13,4 @@ configMapGenerator:
   - files/ircd.yaml
 images:
   - name: ghcr.io/ergochat/ergo
-    newTag: v2.12.0@sha256:759c32c323db7030c6de80fa7f94088307d4485f8ae0d0cb1453afc5928898be
+    newTag: v2.13.0@sha256:cf7b977bd5377d4561014e2bdfc1afaa8881f7abdcd4e03a899bea4637d93fad


### PR DESCRIPTION
It looks like https://github.com/hashbang/gitops/commit/b7fb6e5fc9a44217f6d54ab52206180854ad4120 was never deployed, since the server is still running 2.11.0.