### PR TITLE
upgrade ergo to v2.16.0, enable push notifications

### DIFF
--- a/ircd/files/ircd.yaml
+++ b/ircd/files/ircd.yaml
@@ -844,3 +844,24 @@ history:
 # whether to allow customization of the config at runtime using environment variables,
 # e.g., ORAGONO__SERVER__MAX_SENDQ=128k. see the manual for more details.
 allow-environment-overrides: true
+
+# experimental support for mobile push notifications
+# see the manual for potential security, privacy, and performance implications.
+# DO NOT enable if you are running a Tor or I2P hidden service (i.e. one
+# with no public IP listeners, only Tor/I2P listeners).
+webpush:
+    # are push notifications enabled at all?
+    enabled: true
+    # request timeout for POST'ing the http notification
+    timeout: 10s
+    # delay sending the notification for this amount of time, then suppress it
+    # if the client sent MARKREAD to indicate that it was read on another device
+    delay: 0s
+    # subscriber field for the VAPID JWT authorization:
+    #subscriber: "https://your-website.com/"
+    # maximum number of push subscriptions per user
+    max-subscriptions: 4
+    # expiration time for a push subscription; it must be renewed within this time
+    # by the client reconnecting to IRC. we also detect whether the client is no longer
+    # successfully receiving push messages.
+    expiration: 14d

--- a/ircd/kustomization.yaml
+++ b/ircd/kustomization.yaml
@@ -13,4 +13,4 @@ configMapGenerator:
   - files/ircd.yaml
 images:
   - name: ghcr.io/ergochat/ergo
-    newTag: v2.15.0@sha256:135cd42c6300d957e0045ee53fbe886e43e1c04bb621391ed7b8940c174d68f3
+    newTag: v2.16.0@sha256:40157133cd187c92fcf242292c64677c059d02c1b20e4db337bfd20153ffb0f2


### PR DESCRIPTION
[Ergo v2.16.0](https://github.com/ergochat/ergo/releases/tag/v2.16.0)

[GHCR link](https://github.com/ergochat/ergo/pkgs/container/ergo/417989357?tag=v2.16.0)

Push messages are supported by Goguma and maybe other clients in the future. Pushed message content is encrypted between the ircd and the handset, but the encryption is not post-quantum or forward-secret.